### PR TITLE
chore: Add dh-dkms as build dependency for Ubuntu 23.04 (Lunar)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Jeremy Soller <jeremy@system76.com>
 Build-Depends:
   debhelper (>=9),
+  dh-dkms,
   dkms
 Standards-Version: 4.1.1
 Homepage: https://github.com/pop-os/system76-acpi-dkms


### PR DESCRIPTION
Checking if this resolves the build issue on Launchpad.

Before the change:
```
Command: dpkg-buildpackage -us -uc -mLaunchpad Build Daemon <buildd@lcy02-amd64-074.buildd> -b -rfakeroot
dpkg-buildpackage: info: source package system76-acpi-dkms
dpkg-buildpackage: info: source version 1.0.2~1678132042~23.04~ed01124~dev
dpkg-buildpackage: info: source distribution lunar
 dpkg-source --before-build .
dpkg-buildpackage: info: host architecture amd64
 fakeroot debian/rules clean
dh clean --with dkms
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
dh: error: unable to load addon dkms: Can't locate Debian/Debhelper/Sequence/dkms.pm in @INC (you may need to install the Debian::Debhelper::Sequence::dkms module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/x86_64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at (eval 10) line 1.
BEGIN failed--compilation aborted at (eval 10) line 1.

make: *** [debian/rules:6: clean] Error 25
dpkg-buildpackage: error: fakeroot debian/rules clean subprocess returned exit status 2
--------------------------------------------------------------------------------
Build finished at 2023-04-26T23:20:00Z
```