### PR TITLE
Sync with Linux 6.8.0

### DIFF
--- a/system76_acpi.c
+++ b/system76_acpi.c
@@ -615,7 +615,7 @@ static const struct hwmon_ops thermal_ops = {
 };
 
 // Allocate up to 8 fans and temperatures
-static const struct hwmon_channel_info *thermal_channel_info[] = {
+static const struct hwmon_channel_info * const thermal_channel_info[] = {
 	HWMON_CHANNEL_INFO(fan,
 		HWMON_F_INPUT | HWMON_F_LABEL,
 		HWMON_F_INPUT | HWMON_F_LABEL,


### PR DESCRIPTION
This applies the following commits from upstream:

- torvalds/linux@ddd4e9d78057 ("platform/x86: system76: constify pointers to hwmon_channel_info")